### PR TITLE
Extend props to allow styling of active tab's text

### DIFF
--- a/src/DynamicTabView.js
+++ b/src/DynamicTabView.js
@@ -194,6 +194,7 @@ DynamicTabView.propTypes = {
   //header style props
   headerBackgroundColor: PropTypes.any,
   headerTextStyle: PropTypes.any,
+  headerActiveTextStyle: PropTypes.any,
   highlightStyle: PropTypes.any,
   noHighlightStyle: PropTypes.any,
   headerUnderlayColor: PropTypes.any,

--- a/src/DynamicTabView.js
+++ b/src/DynamicTabView.js
@@ -116,6 +116,7 @@ class DynamicTabView extends React.Component {
           selectedTab={this.state.index}
           headerBackgroundColor={this.props.headerBackgroundColor}
           headerTextStyle={this.props.headerTextStyle}
+          headerActiveTextStyle={this.props.headerActiveTextStyle}
           headerUnderlayColor={this.props.headerUnderlayColor}
           highlightStyle={this.props.highlightStyle}
         />

--- a/src/DynamicTabViewScrollHeader.js
+++ b/src/DynamicTabViewScrollHeader.js
@@ -14,7 +14,7 @@ class DynamicTabViewScrollHeader extends React.Component {
     this.props.goToPage(index);
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.selectedTab !== this.props.selectedTab) {
       this.setState({ selected: nextProps.selectedTab });
     }
@@ -37,7 +37,7 @@ class DynamicTabViewScrollHeader extends React.Component {
             style={[
               { fontWeight: fontWeight },
               this.defaultStyle.tabItemText,
-              this.props.headerTextStyle
+              isTabActive ? this.props.headerActiveTextStyle : this.props.headerTextStyle
             ]}
           >
             {item["title"]}


### PR DESCRIPTION
I wanted to allow users to supply an individual style for the selected tab's header label and thought maybe you like the idea.